### PR TITLE
limit length of messages to 160

### DIFF
--- a/src/Chirp.Core/Entities/Cheep.cs
+++ b/src/Chirp.Core/Entities/Cheep.cs
@@ -7,6 +7,7 @@ public class Cheep
     [Key]
     public int Id { get; set; }
     public required int AuthorId { get; set; }
+    [StringLength(160)]
     public required string Message { get; set; }
     public required DateTime TimeStamp { get; set; }
     public required Author Author { get; set; }


### PR DESCRIPTION
This is to comply with last weeks requirement of limited message length

The Database is not currently migrated yet, but this could be done later