### PR TITLE
Repos is now using split query

### DIFF
--- a/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/AuthorRepository.cs
@@ -27,6 +27,7 @@ public class AuthorRepository(CheepDbContext context) : IAuthorRepository
             .Include(a => a.Cheeps)
             .Include(a => a.Following)
             .Include(a => a.Followers)
+            .AsSplitQuery()
             .FirstOrDefaultAsync();
 
         return author;
@@ -66,6 +67,7 @@ public class AuthorRepository(CheepDbContext context) : IAuthorRepository
             .Include(c => c.Author)
             .Include(c => c.Likes)
             .Include(c => c.Revisions.OrderByDescending(r => r.TimeStamp))
+            .AsSplitQuery()
             .OrderByDescending(c => c.Revisions.First().TimeStamp)
             .Paginate(page)
             .ToList();
@@ -95,6 +97,7 @@ public class AuthorRepository(CheepDbContext context) : IAuthorRepository
         .Include(c => c.Likes)
         .Include(c => c.Revisions)
         .Include(c => c.Comments)
+        .AsSplitQuery()
         .ToListAsync();
 
         // Cheeps form follwing
@@ -107,6 +110,7 @@ public class AuthorRepository(CheepDbContext context) : IAuthorRepository
         .Include(c => c.Likes)
         .Include(c => c.Revisions)
         .Include(c => c.Comments)
+        .AsSplitQuery()
         .ToListAsync();
 
         // Combine results
@@ -141,6 +145,7 @@ public class AuthorRepository(CheepDbContext context) : IAuthorRepository
             .Include(c => c.Revisions.OrderByDescending(r => r.TimeStamp))
             .Include(c => c.Author)
             .Include(c => c.Likes)
+            .AsSplitQuery()
             .OrderByDescending(c => c.Revisions.First().TimeStamp)
             .Paginate(page)
             .ToList();

--- a/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/Repositories/CheepRepository.cs
@@ -23,6 +23,7 @@ public class CheepRepository(CheepDbContext context) : ICheepRepository
             .Include(c => c.Comments).ThenInclude(c => c.Author).ThenInclude(a => a.Followers)
             .Include(c => c.Comments).ThenInclude(c => c.Likes)
 
+            .AsSplitQuery()
             .OrderByDescending(c => c.Revisions.First().TimeStamp)
             .Paginate(page)
             .ToListAsync();
@@ -43,6 +44,7 @@ public class CheepRepository(CheepDbContext context) : ICheepRepository
             .Include(c => c.Author)
             .Include(c => c.Revisions.OrderByDescending(r => r.TimeStamp))
             .Include(c => c.Likes)
+            .AsSplitQuery()
             .FirstOrDefault(c => c.Id == id);
 
         return Task.FromResult(cheep);
@@ -59,6 +61,7 @@ public class CheepRepository(CheepDbContext context) : ICheepRepository
             .Include(c => c.Comments).ThenInclude(c => c.Author).ThenInclude(a => a.Followers)
             .Include(c => c.Comments).ThenInclude(c => c.Likes)
 
+            .AsSplitQuery()
             .Search(searchQuery, x => x.Revisions.First().Message)
             .OrderByDescending(c => c.Revisions.Last().TimeStamp)
             .Paginate(page)
@@ -131,6 +134,7 @@ public class CheepRepository(CheepDbContext context) : ICheepRepository
             .Where(c => c.Id == cheepId)
             .Include(c => c.Likes)
             .Include(c => c.Revisions)
+            .AsSplitQuery()
             .FirstOrDefault() ?? throw new Exception("Cheep not found for delete");
         _context.Cheeps.Remove(cheepToDelete);
 


### PR DESCRIPTION
I have set the queries with multiple includes to use `.AsSplitQuery()`. This tells EF Core to fetch the data with multiple queries. In theory this could lead to some inconsistencies when fetching data. For example when fetching the followers of an author. If another author follows while the data is being, then that could not be reflected in the first still running query.