### PR TITLE
Shortened release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,16 +7,17 @@ on:
 
 env:
   DOTNET_VERSION: '8.0.x'
-
-  LINUX_BUILD_NAME: "${{ github.event.repository.name }}-${{ github.ref_name }}-linux-x64"
-  MACOS_BUILD_NAME: "${{ github.event.repository.name }}-${{ github.ref_name }}-macos-x64"
-  WINDOWS_BUILD_NAME: "${{ github.event.repository.name }}-${{ github.ref_name }}-windows-x64"
+  BUILD_NAME: "${{ github.event.repository.name }}-${{ github.ref_name }}"
 
 permissions:
   contents: write
 
 jobs:
-  build-linux:
+  build:
+    strategy:
+      matrix:
+        target: [linux-x64, osx-x64, win-x64]
+
     runs-on: ubuntu-latest
 
     steps:
@@ -27,59 +28,19 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Build
-      run: dotnet publish src/Chirp.Web -c Release -o "$LINUX_BUILD_NAME" -r linux-x64 --self-contained false
+      run: dotnet publish src/Chirp.Web -c Release -o "${{ env.BUILD_NAME }}-${{ matrix.target }}" -r ${{ matrix.target }} --self-contained false
     - name: Compress
-      run: 7z -tzip a "$LINUX_BUILD_NAME.zip" "./$LINUX_BUILD_NAME/*"
-    - name: Upload artifact
+      run: 7z -tzip a "${{ env.BUILD_NAME }}-${{ matrix.target }}.zip" "./${{ env.BUILD_NAME }}-${{ matrix.target }}/*"
+    - name: Upload
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.LINUX_BUILD_NAME }}.zip
-        path: ./${{ env.LINUX_BUILD_NAME }}.zip
-
-  build-macos:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET ${{ env.DOTNET_VERSION }}
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
-
-    - name: Build
-      run: dotnet publish src/Chirp.Web -c Release -o "$MACOS_BUILD_NAME" -r osx-x64 --self-contained false
-    - name: Compress
-      run: 7z -tzip a "$MACOS_BUILD_NAME.zip" "./$MACOS_BUILD_NAME/*"
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.MACOS_BUILD_NAME }}.zip
-        path: ./${{ env.MACOS_BUILD_NAME }}.zip
-
-  build-windows:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET ${{ env.DOTNET_VERSION }}
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
-
-    - name: Build
-      run: dotnet publish src/Chirp.Web -c Release -o "$WINDOWS_BUILD_NAME" -r win-x64 --self-contained false
-    - name: Compress
-      run: 7z -tzip a "$WINDOWS_BUILD_NAME.zip" "./$WINDOWS_BUILD_NAME/*"
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.WINDOWS_BUILD_NAME }}.zip
-        path: ./${{ env.WINDOWS_BUILD_NAME }}.zip
+        name: ${{ env.BUILD_NAME }}-${{ matrix.target }}.zip
+        path: ./${{ env.BUILD_NAME }}-${{ matrix.target }}.zip
 
   release:
     runs-on: ubuntu-latest
 
-    needs: [build-linux, build-macos, build-windows]
+    needs: [build]
 
     steps:
     - name: Download artifacts


### PR DESCRIPTION
The Github workflow is now using a matrix to determine the build targets.